### PR TITLE
Bug Fixes to netrw explorer

### DIFF
--- a/lua/shr/netrw.lua
+++ b/lua/shr/netrw.lua
@@ -3,6 +3,10 @@
 --- Put cursor to opened file
 --- Remember
 
+local M = {
+    splitSize = 40
+}
+
 local log = require("util.log")
 
 -- setting the listing style to 3
@@ -99,6 +103,30 @@ local closeBufferAndWindow = function(T)
     log.info("Closed our netrw buffer & window")
 end
 
+--- Open a window for netrw buffer
+--- return the windowId
+--- return nil in case of errors
+--- @return integer|nil
+local openSplitWindow = function()
+    local cmd = "topleft" .. " " .. M.splitSize .. "vsplit"
+    vim.cmd(cmd)
+    local win = vim.api.nvim_get_current_win()
+    return win
+end
+
+--- Open a netrw buffer in given window
+--- return bufferId
+--- return nil in case of errors
+--- @param win integer
+--- @return integer|nil
+local openNetrwBuffer = function(win)
+    local cmd = "Ex"
+    vim.api.nvim_set_current_win(win)
+    vim.cmd(cmd)
+    local bufnr = vim.api.nvim_get_current_buf()
+    return bufnr
+end
+
 --- Open netrw window
 --- Save launchwin - window from which netrw explorer launched
 --- Save launchtab - tab from which netrw exploreer launched
@@ -110,10 +138,8 @@ local openNetrwWindow = function()
     _G.netrw_state.have_buffer = true
     _G.netrw_state.launchwin = vim.api.nvim_get_current_win()
     _G.netrw_state.launchtab = vim.api.nvim_get_current_tabpage()
-    vim.cmd("40vsplit")
-    _G.netrw_state.win = vim.api.nvim_get_current_win()
-    vim.cmd("Ex")
-    _G.netrw_state.bufnr = vim.api.nvim_get_current_buf()
+    _G.netrw_state.win = openSplitWindow()
+    _G.netrw_state.bufnr = openNetrwBuffer(_G.netrw_state.win)
     log.info("Opened Netrw Window")
     releaseLock()
 end

--- a/lua/shr/netrw.lua
+++ b/lua/shr/netrw.lua
@@ -3,15 +3,32 @@
 --- Put cursor to opened file
 --- Remember
 
-local M = {
-    splitSize = 40
-}
-
 local log = require("util.log")
 
--- setting the listing style to 3
-vim.g.netrw_liststyle = 3
+--- @class ui_settings
+--- @field netrw_liststyle integer
+--- @field laststatus integer
 
+--- @class netrw_explorer_configs
+--- @field splitSize integer
+--- @field ui_settings ui_settings
+
+
+--- Confis of Explorers
+--- @type netrw_explorer_configs
+local M = {
+    splitSize = 40,
+    ui_settings = {
+        laststatus = 3,
+        netrw_liststyle = 3
+    }
+}
+--- current settings of user
+--- @type ui_settings
+local default_setting = {
+    netrw_liststyle = vim.g.netrw_liststyle,
+    laststatus = vim.o.laststatus
+}
 --- @class netrw_state
 ---@field have_buffer boolean
 ---@field bufnr integer|nil
@@ -19,7 +36,6 @@ vim.g.netrw_liststyle = 3
 ---@field launchwin integer|nil
 ---@field launchtab integer|nil
 ---@field have_lock boolean
-
 ---@type netrw_state
 local netrw_default_state = {
     have_buffer = false,
@@ -27,8 +43,42 @@ local netrw_default_state = {
     win = nil,
     launchwin = nil,
     launchtab = nil,
-    have_lock = true
+    have_lock = true,
 }
+
+-- Setting up settings specific to netrw
+-- buffer specific settings so should be called after buffer has been set-uped
+local setupNetrwExplorerSettings = function()
+    vim.b.netrw_liststyle = M.ui_settings.netrw_liststyle
+end
+
+--- Cleaning up settings specific to netrw
+local cleanUpNetrwExplorerSettings = function()
+    vim.b.netrw_liststyle = default_setting.netrw_liststyle
+end
+
+--- Setting up settings of UI
+local setupUIForExplorerSettings = function()
+    vim.o.laststatus = M.ui_settings.laststatus
+end
+
+--- Cleanup settings specific to UI
+local cleanUpUIForExplorerSettings = function()
+    vim.o.laststatus = default_setting.laststatus
+end
+
+--- Setting up all settings related to UI & netrw
+local function setupAllSettings()
+    setupNetrwExplorerSettings()
+    setupUIForExplorerSettings()
+end
+
+--- Cleaning up all settings related to UI & netrw
+local function cleanUpAllSettings()
+    cleanUpUIForExplorerSettings()
+    cleanUpNetrwExplorerSettings()
+end
+
 --- Get fresh default state of netrw
 --- @return netrw_state
 local get_new_state = function()
@@ -43,7 +93,7 @@ _G.netrw_state = get_new_state()
 --- @param T netrw_state | nil
 local closeWindow = function(T)
     T = T or _G.netrw_state
-    if vim.api.nvim_win_is_valid(T.win) then
+    if T.win ~= nil and vim.api.nvim_win_is_valid(T.win) then
         vim.api.nvim_win_close(T.win, true)
     end
     T.win = netrw_default_state.win
@@ -55,7 +105,7 @@ end
 --- @param T netrw_state | nil
 local closeBuffer = function(T)
     T = T or _G.netrw_state
-    if vim.api.nvim_buf_is_valid(T.bufnr) then
+    if T.bufnr ~= nil and vim.api.nvim_buf_is_valid(T.bufnr) then
         vim.api.nvim_buf_delete(T.bufnr, {})
     end
     T.bufnr = netrw_default_state.bufnr
@@ -141,6 +191,7 @@ local openNetrwWindow = function()
     _G.netrw_state.win = openSplitWindow()
     _G.netrw_state.bufnr = openNetrwBuffer(_G.netrw_state.win)
     log.info("Opened Netrw Window")
+    setupAllSettings()
     releaseLock()
 end
 
@@ -197,6 +248,19 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
     end,
     group = netrw_group
 })
+
+--- When netrw buffer is closed close window as well
+vim.api.nvim_create_autocmd({ "BufDelete", "BufHidden", "WinClosed" }, {
+    callback = function(ev)
+        if _G.netrw_state.have_buffer then
+            if _G.netrw_state.bufnr == ev.buf then
+                closeBufferAndWindow()
+                cleanUpAllSettings()
+            end
+        end
+    end
+})
+
 --- Close the opened Netrw Explorer before switching tab
 vim.api.nvim_create_autocmd("TabLeave", {
     callback = function()
@@ -211,4 +275,25 @@ vim.api.nvim_create_user_command("ToggleNetrwExplorer",
     toggleNetrwExplorer,
     {}
 )
+--- reset the UI settings
+vim.api.nvim_create_autocmd("WinLeave", {
+    callback = function()
+        if _G.netrw_state.have_buffer then
+            if _G.netrw_state.win == vim.api.nvim_get_current_win() then
+                cleanUpUIForExplorerSettings()
+            end
+        end
+    end
+})
+
+--- set the ui settings when win enter
+vim.api.nvim_create_autocmd("WinEnter", {
+    callback = function(e)
+        if _G.netrw_state.have_buffer then
+            if _G.netrw_state.win == vim.api.nvim_get_current_win() then
+                setupUIForExplorerSettings()
+            end
+        end
+    end
+})
 

--- a/lua/shr/netrw.lua
+++ b/lua/shr/netrw.lua
@@ -47,14 +47,13 @@ local netrw_default_state = {
 }
 
 -- Setting up settings specific to netrw
--- buffer specific settings so should be called after buffer has been set-uped
 local setupNetrwExplorerSettings = function()
-    vim.b.netrw_liststyle = M.ui_settings.netrw_liststyle
+    vim.g.netrw_liststyle = M.ui_settings.netrw_liststyle
 end
 
 --- Cleaning up settings specific to netrw
 local cleanUpNetrwExplorerSettings = function()
-    vim.b.netrw_liststyle = default_setting.netrw_liststyle
+    vim.g.netrw_liststyle = default_setting.netrw_liststyle
 end
 
 --- Setting up settings of UI
@@ -171,9 +170,9 @@ end
 --- @return integer|nil
 local openNetrwBuffer = function(win)
     local cmd = "Ex"
-    vim.api.nvim_set_current_win(win)
+    local bufnr = vim.api.nvim_create_buf(false, false)
+    vim.api.nvim_win_set_buf(win, bufnr)
     vim.cmd(cmd)
-    local bufnr = vim.api.nvim_get_current_buf()
     return bufnr
 end
 
@@ -185,13 +184,14 @@ end
 --- Save bufnr - netrw buffer
 local openNetrwWindow = function()
     acquireLock()
+    setupAllSettings()
     _G.netrw_state.have_buffer = true
     _G.netrw_state.launchwin = vim.api.nvim_get_current_win()
     _G.netrw_state.launchtab = vim.api.nvim_get_current_tabpage()
     _G.netrw_state.win = openSplitWindow()
     _G.netrw_state.bufnr = openNetrwBuffer(_G.netrw_state.win)
+    vim.api.nvim_set_current_win(_G.netrw_state.win)
     log.info("Opened Netrw Window")
-    setupAllSettings()
     releaseLock()
 end
 
@@ -269,12 +269,6 @@ vim.api.nvim_create_autocmd("TabLeave", {
         end
     end
 })
---- User command to Open/Close Explorer
---- Will be used in keymapping
-vim.api.nvim_create_user_command("ToggleNetrwExplorer",
-    toggleNetrwExplorer,
-    {}
-)
 --- reset the UI settings
 vim.api.nvim_create_autocmd("WinLeave", {
     callback = function()
@@ -296,4 +290,11 @@ vim.api.nvim_create_autocmd("WinEnter", {
         end
     end
 })
+
+--- User command to Open/Close Explorer
+--- Will be used in keymapping
+vim.api.nvim_create_user_command("ToggleNetrwExplorer",
+    toggleNetrwExplorer,
+    {}
+)
 

--- a/lua/shr/netrw.lua
+++ b/lua/shr/netrw.lua
@@ -197,7 +197,14 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
     end,
     group = netrw_group
 })
-
+--- Close the opened Netrw Explorer before switching tab
+vim.api.nvim_create_autocmd("TabLeave", {
+    callback = function()
+        if _G.netrw_state.have_buffer then
+            closeBufferAndWindow()
+        end
+    end
+})
 --- User command to Open/Close Explorer
 --- Will be used in keymapping
 vim.api.nvim_create_user_command("ToggleNetrwExplorer",


### PR DESCRIPTION

---- Bugs

- [x] When opened/switched to different tab then opened netrw tab & call `ToogleNetrwExplorer` will close the explorer in prev but does not show in current one
- [x] If buffer is closed by :bd & then used `ToggleNetrwExplorer` will not open Explorer on first attemp
- [x] Explorer should open to left side of window
- [x] If i have horizontal split window & call `ToggleNetrwExplorer` will split the horizontal window in vertical split should open a wide vertical to left side of window